### PR TITLE
With 0.14.x plugin, proGuard flag was removed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
With the 0.14.x version of the Android plugin, the `proGuard` flag was removed and replaced with `minifyEnabled`.

This makes the project build again.
